### PR TITLE
LRCI-7434 Make pull request optional in SanitizeLanguageTopLevelBuild

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SanitizeLanguageTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SanitizeLanguageTopLevelBuild.java
@@ -16,16 +16,23 @@ public class SanitizeLanguageTopLevelBuild
 
 		super(buildURL, topLevelBuild);
 
-		StringBuilder sb = new StringBuilder();
+		String pullRequestNumber = getParameterValue(
+			"GITHUB_PULL_REQUEST_NUMBER");
 
-		sb.append("https://github.com/");
-		sb.append(getParameterValue("GITHUB_RECEIVER_USERNAME"));
-		sb.append("/liferay-portal");
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(pullRequestNumber)) {
+			StringBuilder sb = new StringBuilder();
 
-		sb.append("/pull/");
-		sb.append(getParameterValue("GITHUB_PULL_REQUEST_NUMBER"));
+			sb.append("https://github.com/");
+			sb.append(getParameterValue("GITHUB_RECEIVER_USERNAME"));
+			sb.append("/liferay-portal");
+			sb.append("/pull/");
+			sb.append(pullRequestNumber);
 
-		_pullRequest = PullRequestFactory.newPullRequest(sb.toString());
+			_pullRequest = PullRequestFactory.newPullRequest(sb.toString());
+		}
+		else {
+			_pullRequest = null;
+		}
 	}
 
 	@Override
@@ -82,7 +89,9 @@ public class SanitizeLanguageTopLevelBuild
 		WorkspaceGitRepository workspaceGitRepository =
 			workspace.getPrimaryWorkspaceGitRepository();
 
-		workspaceGitRepository.setGitHubURL(pullRequest.getHtmlURL());
+		if (pullRequest != null) {
+			workspaceGitRepository.setGitHubURL(pullRequest.getHtmlURL());
+		}
 
 		String senderBranchSHA = _getSenderBranchSHA();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SanitizeLanguageTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SanitizeLanguageTopLevelBuild.java
@@ -42,7 +42,14 @@ public class SanitizeLanguageTopLevelBuild
 
 	@Override
 	public String getBranchName() {
-		return getParameterValue("GITHUB_UPSTREAM_BRANCH_NAME");
+		String upstreamBranchName = getParameterValue(
+			"GITHUB_UPSTREAM_BRANCH_NAME");
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(upstreamBranchName)) {
+			return "master";
+		}
+
+		return upstreamBranchName;
 	}
 
 	@Override
@@ -77,8 +84,7 @@ public class SanitizeLanguageTopLevelBuild
 		PullRequest pullRequest = getPullRequest();
 
 		Workspace workspace = WorkspaceFactory.newWorkspace(
-			"liferay-portal", getParameterValue("GITHUB_UPSTREAM_BRANCH_NAME"),
-			"sanitize-language");
+			"liferay-portal", getBranchName(), "sanitize-language");
 
 		if (workspace instanceof PortalWorkspace) {
 			PortalWorkspace portalWorkspace = (PortalWorkspace)workspace;


### PR DESCRIPTION
## Summary

- Guard `_pullRequest` construction behind a null/empty check on `GITHUB_PULL_REQUEST_NUMBER`
- Guard `setGitHubURL` in `getWorkspace()` so it is only called when a PR is present

## Test plan

- [ ] `gradlew test jar` passes in `modules/test/jenkins-results-parser/` (no new failures)
- [ ] Trigger `sanitize-language` on CI with full PR params — verify PR comment/close still works
- [ ] Trigger `sanitize-language` on CI with no PR params — verify build succeeds (or fails cleanly on errors) without crashing in `start-current-job`