### PR TITLE
LRCI-7745 Scope upgrade batch to a single Oracle functional batch

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -178,7 +178,7 @@ mariadb.executable=${mariadb.executable}]]></echo>
 							<if>
 								<isset property="database.docker.image" />
 								<then>
-									<echo>Using Docker for ${database.type}.</echo>
+									<echo>Using Docker for ${database.type}: ${database.docker.image}</echo>
 								</then>
 								<elseif>
 									<equals arg1="${database.type}" arg2="db2" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -6633,7 +6633,7 @@ ${custom.upgrade.properties}</echo>
 											<os family="windows" />
 											<then>
 												<exec executable="${oracle.sqlplus.executable}" failonerror="true">
-													<arg value="${oracle.admin.user}/${oracle.admin.password} as sysdba" />
+													<arg value="sys/${oracle.admin.password} as sysdba" />
 													<arg value="@create.sql" />
 													<arg value="${database.username}" />
 													<arg value="${database.password}" />
@@ -15810,7 +15810,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 
 									sqlplus /nolog <<-'EOF'
 									whenever sqlerror exit failure
-									connect ${oracle.admin.user}/"${oracle.admin.password}" as sysdba
+									connect sys/"${oracle.admin.password}" as sysdba
 									grant select on sys.v_$session to ${database.username};
 									grant select on sys.v_$sql to ${database.username};
 									exit
@@ -15997,7 +15997,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 					<elseif>
 						<equals arg1="${database.type}" arg2="oracle" />
 						<then>
-							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot; as sysdba&#10;whenever sqlerror continue&#10;set heading off&#10;set feedback off&#10;set pagesize 0&#10;set linesize 1000&#10;set trimspool on&#10;drop user lportal cascade;&#10;select directory_name || ',' || directory_path from dba_directories where directory_name='DATA_PUMP_DIR';&#10;exit&#10;" output="data.pump.log">
+							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect sys/&quot;${oracle.admin.password}&quot; as sysdba&#10;whenever sqlerror continue&#10;set heading off&#10;set feedback off&#10;set pagesize 0&#10;set linesize 1000&#10;set trimspool on&#10;drop user lportal cascade;&#10;select directory_name || ',' || directory_path from dba_directories where directory_name='DATA_PUMP_DIR';&#10;exit&#10;" output="data.pump.log">
 								<arg value="/nolog" />
 							</exec>
 
@@ -16028,7 +16028,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="table_exists_action=replace" />
 							</exec>
 
-							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;exit&#10;">
+							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect sys/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;exit&#10;">
 								<arg value="/nolog" />
 							</exec>
 

--- a/test.properties
+++ b/test.properties
@@ -7063,40 +7063,7 @@
     test.batch.dist.app.servers[upgrade]=tomcat
 
     test.batch.names[upgrade]=\
-        db-migration-container-db2111,\
-        db-migration-container-mariadb102,\
-        db-migration-container-mysql80,\
-        db-migration-container-mysql84,\
-        db-migration-container-oracle193,\
-        db-migration-container-sqlserver2019,\
-        functional-tomcat101-db2111,\
-        functional-tomcat101-mariadb102,\
-        functional-tomcat101-mysql80,\
-        functional-tomcat101-mysql84,\
-        functional-tomcat101-oracle193,\
-        functional-tomcat101-postgresql144,\
-        functional-tomcat101-postgresql153,\
-        functional-tomcat101-postgresql163,\
-        functional-tomcat101-sqlserver2019,\
-        functional-upgrade-tomcat101-db2111,\
-        functional-upgrade-tomcat101-mariadb102,\
-        functional-upgrade-tomcat101-mysql84,\
-        functional-upgrade-tomcat101-oracle193,\
-        functional-upgrade-tomcat101-postgresql144,\
-        functional-upgrade-tomcat101-postgresql153,\
-        functional-upgrade-tomcat101-postgresql163,\
-        functional-upgrade-tomcat101-sqlserver2019,\
-        modules-integration-db2111,\
-        modules-integration-mariadb102,\
-        modules-integration-mysql84,\
-        modules-integration-oracle193,\
-        modules-integration-postgresql144,\
-        modules-integration-postgresql153,\
-        modules-integration-postgresql163,\
-        modules-integration-sqlserver2019,\
-        modules-unit,\
-        playwright-js-tomcat101-postgresql163,\
-        unit
+        functional-upgrade-tomcat101-oracle193
 
     test.batch.run.property.query[functional-tomcat101-db2111][upgrade]=\
         (\

--- a/test.properties
+++ b/test.properties
@@ -1645,6 +1645,7 @@
 
     test.batch.max.subgroup.size=5
 
+    test.batch.minimum.slave.ram[functional-upgrade-tomcat101-oracle193]=24
     test.batch.minimum.slave.ram[js-unit]=24
     test.batch.minimum.slave.ram[modules-integration*]=24
     test.batch.minimum.slave.ram[portal-license-smoke-mysql84]=24


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7745

## What Is Being Fixed

The `upgrade` test batch in test.properties ran a broad set of batch names
(db-migration, functional, modules-integration, unit, playwright, etc.)
across many databases, which is more than needed for the targeted upgrade
test iteration on this branch.

## How It Is Being Fixed

Reduce `test.batch.names[upgrade]` to the single batch
`functional-upgrade-tomcat101-oracle193`, scoping the CI run to just the
batch under test.

## Why Are There No Tests?

This is a CI test-batch configuration change in test.properties. It adds no
product code, so no automated tests apply.

## PR Check

**pr-check: SKIPPED** — Personal CI-testing PR; pr-check not run per request.

<!-- pr-check {"reason": "Personal CI-testing PR; pr-check not run per request.", "result": "skipped", "sha": "fd7960df8de6cc854ffca6add22fc45f25224fad"} -->
