### PR TITLE
LRCI-7745 Limit upgrade suite to Oracle 19 functional and functional-upgrade axes

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1633,10 +1633,10 @@
 
     test.batch.max.subgroup.size=5
 
-    test.batch.minimum.slave.ram[functional-upgrade-tomcat101-oracle193]=24
     test.batch.minimum.slave.ram[js-unit]=24
     test.batch.minimum.slave.ram[modules-integration*]=24
     test.batch.minimum.slave.ram[portal-license-smoke-mysql84]=24
+    test.batch.minimum.slave.ram[*oracle193*]=24
     test.batch.minimum.slave.ram[*playwright*]=24
     test.batch.minimum.slave.ram[*redhat9*]=24
     test.batch.minimum.slave.ram[*redhat10*]=24

--- a/test.properties
+++ b/test.properties
@@ -7054,40 +7054,8 @@
     test.batch.dist.app.servers[upgrade]=tomcat
 
     test.batch.names[upgrade]=\
-        db-migration-container-db2111,\
-        db-migration-container-mariadb102,\
-        db-migration-container-mysql80,\
-        db-migration-container-mysql84,\
-        db-migration-container-oracle193,\
-        db-migration-container-sqlserver2019,\
-        functional-tomcat101-db2111,\
-        functional-tomcat101-mariadb102,\
-        functional-tomcat101-mysql80,\
-        functional-tomcat101-mysql84,\
         functional-tomcat101-oracle193,\
-        functional-tomcat101-postgresql144,\
-        functional-tomcat101-postgresql153,\
-        functional-tomcat101-postgresql163,\
-        functional-tomcat101-sqlserver2019,\
-        functional-upgrade-tomcat101-db2111,\
-        functional-upgrade-tomcat101-mariadb102,\
-        functional-upgrade-tomcat101-mysql84,\
-        functional-upgrade-tomcat101-oracle193,\
-        functional-upgrade-tomcat101-postgresql144,\
-        functional-upgrade-tomcat101-postgresql153,\
-        functional-upgrade-tomcat101-postgresql163,\
-        functional-upgrade-tomcat101-sqlserver2019,\
-        modules-integration-db2111,\
-        modules-integration-mariadb102,\
-        modules-integration-mysql84,\
-        modules-integration-oracle193,\
-        modules-integration-postgresql144,\
-        modules-integration-postgresql153,\
-        modules-integration-postgresql163,\
-        modules-integration-sqlserver2019,\
-        modules-unit,\
-        playwright-js-tomcat101-postgresql163,\
-        unit
+        functional-upgrade-tomcat101-oracle193
 
     test.batch.run.property.query[functional-tomcat101-db2111][upgrade]=\
         (\


### PR DESCRIPTION
## What

Trims the CI `upgrade` test suite (`test.batch.names[upgrade]` in `test.properties`)
down to only the two Oracle 19 axes:

- `functional-tomcat101-oracle193`
- `functional-upgrade-tomcat101-oracle193`

All other database axes (db2, mariadb, mysql, postgresql, sqlserver, the
`db-migration-container-*`, `modules-integration-*`, `modules-unit`, `unit`, and
`playwright-*` batches) are removed from the suite.

## Why

Focused, fast validation of the Oracle 19 v_$ grant fix (LRCI-7745): the rebuilt
`oracle-19.3.0.0.0:1.0.4` image bakes `GRANT SELECT ON sys.v_$session`/`v_$sql TO
PUBLIC`, which unblocks `OracleDB.getLockedQueryInfos` / `getLongRunningQueryInfos`
and the upgrade query monitor. Running only the oracle193 axes exercises that path
without spinning up every other database.

This is a testing-only branch, not intended to merge into upstream `master`.
