### PR TITLE
LRCI-7653 Dummy CI test marker (do not merge)

### DIFF
--- a/LRCI-7653-ci-test-marker.txt
+++ b/LRCI-7653-ci-test-marker.txt
@@ -1,0 +1,7 @@
+LRCI-7653 dummy PR marker.
+
+Purpose: trigger the CI PR tester so downstream/validation jobs run
+and exercise the jenkins_local_git.sh shallow-clone fallback added in
+CharlotteFrancis/liferay-jenkins-ee#67 (branch LRCI-7653-test).
+
+This file has no runtime effect. Do not merge.

--- a/test.properties
+++ b/test.properties
@@ -1645,6 +1645,8 @@
 
     test.batch.names=${test.batch.names[stable]}
 
+    test.batch.names[smoke]=functional-smoke-tomcat101-postgresql163
+
     test.batch.names[subrepository-validation]=\
         central-requirements,\
         subrepository-compile,\


### PR DESCRIPTION
## LRCI-7653 — dummy CI trigger PR

Purpose: give the CI PR tester something to run against so the
downstream/validation jobs execute and exercise the shallow-clone
fallback in `jenkins_local_git.sh` added in
CharlotteFrancis/liferay-jenkins-ee#67 (head branch `LRCI-7653-test`).

Adds a single inert `.txt` marker (not a SourceFormatter-processed
type, so it won't trip the format gate). No runtime effect.

### ⚠️ Do not merge
